### PR TITLE
Volume control case logic had +/- swapped

### DIFF
--- a/Shadow/Shadow.ino
+++ b/Shadow/Shadow.ino
@@ -491,9 +491,9 @@ void processSoundCommand(char soundCommand)
 {
   switch (soundCommand)
   {
-    case '+':
+    case '-':
 #ifdef SHADOW_DEBUG
-      output += "Volume Up\r\n";
+      output += "Volume Down\r\n";
 #endif
       if (vol > 0)
       {
@@ -509,9 +509,9 @@ void processSoundCommand(char soundCommand)
 
       }
       break;
-    case '-':
+    case '+':
 #ifdef SHADOW_DEBUG
-      output += "Volume Down\r\n";
+      output += "Volume Up\r\n";
 #endif
 
 #ifdef MDFly


### PR DESCRIPTION
Ryan Diaz on the Mouse Droid Facebook group had opposite volume control behavior. The code shows `vol` decremented under the "+" case that D-Pad Up calls. Swapping the case labels change the least lines.